### PR TITLE
Fix Flask-Cors py2 dependence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,6 @@ flask-restful>=0.3.1,<0.4.0
 raven<5.2.0
 blinker
 flask-login<0.3.0
-flask-cors
+flask-cors<4 # Py2
 yamlns>=0.10.0 # yaml_snapshot introduced in this version
 


### PR DESCRIPTION
Heman en python 2 (entenc que el que hi ha a producció) no te el paquet Flask-Cors fixat al requirements.txt, i desde el 26 de juny ha sortit la versió 4.0.0 que es descarrega però que no es compatible amb Python2 i peta en execució (deuen tenir-ho mal configurat)

Aquest PR arregla això :)