### PR TITLE
Remove repeated records from mongo result

### DIFF
--- a/heman/api/cch/mongo_curve_backend.py
+++ b/heman/api/cch/mongo_curve_backend.py
@@ -33,11 +33,12 @@ class MongoCurveBackend:
 
         query = [
             {'$match': match_query },
-            {'$group': {'_id': {'datetime': '$datetime', 'name': '$name'},
-                        'datetime': {'$first': '$datetime'},
-                        'ai': {'$first': '$ai'},
-                        'season': {'$first': '$season'},
-                        }
+            {'$group': {
+                '_id': {'datetime': '$datetime', 'name': '$name'},
+                'datetime': {'$first': '$datetime'},
+                'ai': {'$first': '$ai'},
+                'season': {'$first': '$season'},
+                }
             },
             {'$sort': {
                     'datetime': ASCENDING,

--- a/tests/test_cch.py
+++ b/tests/test_cch.py
@@ -4,6 +4,7 @@ import pytest
 from testdata.curves import (
     tg_cchfact_existing_points,
     tg_cchfact_NOT_existing_points_BUT_f1,
+    tg_cchfact_p1_repeated_records,
 )
 
 from yamlns import ns
@@ -159,4 +160,31 @@ class TestCurveBackend(object):
 
         yaml_snapshot(ns(
             result=list(result)
+        ))
+
+    def test_get_curve_p1_mongo_repeated_records(self, yaml_snapshot):
+        backend = MongoCurveBackend(get_mongo_instance())
+        result = backend.get_curve(
+            curve_type=TgCchP1Repository(backend),
+            start=localisodate('2024-01-06'),
+            end=localisodate('2024-01-07'),
+            cups=tg_cchfact_p1_repeated_records['cups'],
+        )
+
+        yaml_snapshot(ns(
+            result=list(result)
+        ))
+
+    def test_get_curve_p1_timescale_repeated_records(self, yaml_snapshot):
+        backend = TimescaleCurveBackend()
+
+        result = backend.get_curve(
+            curve_type=TgCchP1Repository(backend),
+            start=localisodate('2024-01-06'),
+            end=localisodate('2024-01-07'),
+            cups=tg_cchfact_p1_repeated_records['cups'],
+        )
+
+        yaml_snapshot(ns(
+            result=[x for x in result]
         ))


### PR DESCRIPTION
**Description**

Some CUPs have repeated records in mongo this produce errors in the frontend when totals and barcharts are shown.

**Solution**
Mongo query is changed replacing find by an agregate in the query.